### PR TITLE
Add pify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "is-trademarked": "^1.2.1",
     "npm-list-author-packages": "^2.0.1",
-    "npm-whoami": "^1.1.4"
+    "npm-whoami": "^1.1.4",
+    "pify": "^2.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
This allows using `canibekikked-api` without installing `pify` in the thing that depends on it. It also allows https://tonicdev.com/npm/canibekikked-api to work.
